### PR TITLE
Refactor machine instructions to used linked representation instead of resizable array

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,25 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Fix expect test output">
+    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/pass/ConstantPropagation.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/pass/ConstantPropagation.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/Codegen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/Codegen.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/DAGTile.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/DAGTile.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/SSADAG.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/SSADAG.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineInstruction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineInstruction.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Block.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Block.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Value.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Value.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/select/CodegenTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/select/CodegenTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/ssa/BlockTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/ssa/BlockTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -57,62 +48,62 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Application.Fibonacci.executor": "Run",
-    "Application.FibonacciAARCH64.executor": "Run",
-    "Application.FibonacciX86_64.executor": "Run",
-    "Application.Funswap.executor": "Run",
-    "Application.FunswapAARCH64.executor": "Run",
-    "Application.Gen.executor": "Run",
-    "Application.GenAARCH64.executor": "Run",
-    "Application.GenX86_64.executor": "Run",
-    "Application.Main.executor": "Run",
-    "JUnit.All tests.executor": "Run",
-    "JUnit.BlockTest.createBlocks.executor": "Run",
-    "JUnit.BlockTest.executor": "Run",
-    "JUnit.BuilderTest.convertFunction.executor": "Debug",
-    "JUnit.CodegenTest.codegenAARCH.executor": "Run",
-    "JUnit.CodegenTest.executor": "Run",
-    "JUnit.DataflowTest.genKill.executor": "Run",
-    "JUnit.DataflowTest.genKillAndLiveness.executor": "Run",
-    "JUnit.IntervalTest.addRange.executor": "Run",
-    "JUnit.LengauerTarjanTest.idom.executor": "Run",
-    "JUnit.LinearScanTest.scanAARCH64.executor": "Debug",
-    "JUnit.LinearScanTest.scanX86.executor": "Debug",
-    "JUnit.MachineBasicBlockTest.addBeforeTerminator.executor": "Run",
-    "JUnit.MachineBasicBlockTest.getPhiUses.executor": "Run",
-    "JUnit.ParserTest.parseBinaryExpression.executor": "Debug",
-    "JUnit.ParserTest.parseIfStatement.executor": "Run",
-    "JUnit.ParserTest.parseIfStatementSemicolons.executor": "Run",
-    "JUnit.ParserTest.parseProgram.executor": "Run",
-    "JUnit.ParserTest.parseWhileStatement.executor": "Run",
-    "JUnit.RangeTest.executor": "Run",
-    "JUnit.RangeTest.overlaps.executor": "Run",
-    "JUnit.SSADAGTest.postorder.executor": "Run",
-    "JUnit.ThreeAddressCodeTest.normalize.executor": "Run",
-    "JUnit.UniqueRenamerTest.executor": "Run",
-    "Maven.baby-pascal [clean,compile,exec:java].executor": "Run",
-    "Maven.baby-pascal [clean].executor": "Run",
-    "Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor": "Run",
-    "Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor": "Run",
-    "Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor": "Run",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
-    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
-    "git-widget-placeholder": "linked__machine__instructions",
-    "ignore.preview.features.used": "true",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "/home/d/Documents/mirrored/baby-pascal",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.15",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "editor.preferences.tabs"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Application.Fibonacci.executor&quot;: &quot;Run&quot;,
+    &quot;Application.FibonacciAARCH64.executor&quot;: &quot;Run&quot;,
+    &quot;Application.FibonacciX86_64.executor&quot;: &quot;Run&quot;,
+    &quot;Application.Funswap.executor&quot;: &quot;Run&quot;,
+    &quot;Application.FunswapAARCH64.executor&quot;: &quot;Run&quot;,
+    &quot;Application.Gen.executor&quot;: &quot;Run&quot;,
+    &quot;Application.GenAARCH64.executor&quot;: &quot;Run&quot;,
+    &quot;Application.GenX86_64.executor&quot;: &quot;Run&quot;,
+    &quot;Application.Main.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.All tests.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.BlockTest.createBlocks.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.BlockTest.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.BuilderTest.convertFunction.executor&quot;: &quot;Debug&quot;,
+    &quot;JUnit.CodegenTest.codegenAARCH.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.CodegenTest.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.DataflowTest.genKill.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.DataflowTest.genKillAndLiveness.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.IntervalTest.addRange.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.LengauerTarjanTest.idom.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.LinearScanTest.scanAARCH64.executor&quot;: &quot;Debug&quot;,
+    &quot;JUnit.LinearScanTest.scanX86.executor&quot;: &quot;Debug&quot;,
+    &quot;JUnit.MachineBasicBlockTest.addBeforeTerminator.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.MachineBasicBlockTest.getPhiUses.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.ParserTest.parseBinaryExpression.executor&quot;: &quot;Debug&quot;,
+    &quot;JUnit.ParserTest.parseIfStatement.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.ParserTest.parseIfStatementSemicolons.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.ParserTest.parseProgram.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.ParserTest.parseWhileStatement.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.RangeTest.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.RangeTest.overlaps.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.SSADAGTest.postorder.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.ThreeAddressCodeTest.normalize.executor&quot;: &quot;Run&quot;,
+    &quot;JUnit.UniqueRenamerTest.executor&quot;: &quot;Run&quot;,
+    &quot;Maven.baby-pascal [clean,compile,exec:java].executor&quot;: &quot;Run&quot;,
+    &quot;Maven.baby-pascal [clean].executor&quot;: &quot;Run&quot;,
+    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor&quot;: &quot;Run&quot;,
+    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor&quot;: &quot;Run&quot;,
+    &quot;Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;linked__machine__instructions&quot;,
+    &quot;ignore.preview.features.used&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/home/d/Documents/mirrored/baby-pascal&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;editor.preferences.tabs&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="com.d_m.ast" />
@@ -373,14 +364,6 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1709911294056</updated>
-    </task>
-    <task id="LOCAL-00210" summary="Attempt modification to liveness equations to handle phi nodes">
-      <option name="closed" value="true" />
-      <created>1729955149695</created>
-      <option name="number" value="00210" />
-      <option name="presentableId" value="LOCAL-00210" />
-      <option name="project" value="LOCAL" />
-      <updated>1729955149695</updated>
     </task>
     <task id="LOCAL-00211" summary="Add unit tests for getPhiUses() and getPhiDefs()">
       <option name="closed" value="true" />
@@ -766,7 +749,15 @@
       <option name="project" value="LOCAL" />
       <updated>1752965697472</updated>
     </task>
-    <option name="localTasksCounter" value="259" />
+    <task id="LOCAL-00259" summary="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList">
+      <option name="closed" value="true" />
+      <created>1753039713658</created>
+      <option name="number" value="00259" />
+      <option name="presentableId" value="LOCAL-00259" />
+      <option name="project" value="LOCAL" />
+      <updated>1753039713658</updated>
+    </task>
+    <option name="localTasksCounter" value="260" />
     <servers />
   </component>
   <component name="UnknownFeatures">
@@ -774,7 +765,6 @@
     <option featureType="com.intellij.fileTypeFactory" implementationName="*.rule" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Writes stack slots in assembly" />
     <MESSAGE value="Use temporary register as middleman for moves between two memory operands" />
     <MESSAGE value="Start baby pascal scanner and parser" />
     <MESSAGE value="Parse types and typed names" />
@@ -799,7 +789,8 @@
     <MESSAGE value="Abstract out backend isa specific stuff into a Compiler interface" />
     <MESSAGE value="Build examples with AARCH64 and set up build scripts for AARCH64" />
     <MESSAGE value="Fix expect test output" />
-    <option name="LAST_COMMIT_MESSAGE" value="Fix expect test output" />
+    <MESSAGE value="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList" />
+    <option name="LAST_COMMIT_MESSAGE" value="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,25 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Build examples with AARCH64 and set up build scripts for AARCH64">
+    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Fix expect test output">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/regalloc/linear/LinearScanTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/regalloc/linear/LinearScanTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/Codegen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/Codegen.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/DAGTile.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/DAGTile.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/SSADAG.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/SSADAG.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineInstruction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineInstruction.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Value.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Value.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/select/CodegenTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/select/CodegenTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -42,59 +57,62 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Application.Fibonacci.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FibonacciAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FibonacciX86_64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Funswap.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FunswapAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Gen.executor&quot;: &quot;Run&quot;,
-    &quot;Application.GenAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.GenX86_64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Main.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.All tests.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BlockTest.createBlocks.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BlockTest.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BuilderTest.convertFunction.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.DataflowTest.genKill.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.DataflowTest.genKillAndLiveness.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.IntervalTest.addRange.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.LengauerTarjanTest.idom.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.LinearScanTest.scanAARCH64.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.LinearScanTest.scanX86.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.MachineBasicBlockTest.addBeforeTerminator.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.MachineBasicBlockTest.getPhiUses.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseBinaryExpression.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.ParserTest.parseIfStatement.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseIfStatementSemicolons.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseProgram.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseWhileStatement.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.RangeTest.overlaps.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.SSADAGTest.postorder.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ThreeAddressCodeTest.normalize.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.UniqueRenamerTest.executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [clean,compile,exec:java].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [clean].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;master&quot;,
-    &quot;ignore.preview.features.used&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/home/d/Documents/mirrored/baby-pascal&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;editor.preferences.tabs&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Application.Fibonacci.executor": "Run",
+    "Application.FibonacciAARCH64.executor": "Run",
+    "Application.FibonacciX86_64.executor": "Run",
+    "Application.Funswap.executor": "Run",
+    "Application.FunswapAARCH64.executor": "Run",
+    "Application.Gen.executor": "Run",
+    "Application.GenAARCH64.executor": "Run",
+    "Application.GenX86_64.executor": "Run",
+    "Application.Main.executor": "Run",
+    "JUnit.All tests.executor": "Run",
+    "JUnit.BlockTest.createBlocks.executor": "Run",
+    "JUnit.BlockTest.executor": "Run",
+    "JUnit.BuilderTest.convertFunction.executor": "Debug",
+    "JUnit.CodegenTest.codegenAARCH.executor": "Run",
+    "JUnit.CodegenTest.executor": "Run",
+    "JUnit.DataflowTest.genKill.executor": "Run",
+    "JUnit.DataflowTest.genKillAndLiveness.executor": "Run",
+    "JUnit.IntervalTest.addRange.executor": "Run",
+    "JUnit.LengauerTarjanTest.idom.executor": "Run",
+    "JUnit.LinearScanTest.scanAARCH64.executor": "Debug",
+    "JUnit.LinearScanTest.scanX86.executor": "Debug",
+    "JUnit.MachineBasicBlockTest.addBeforeTerminator.executor": "Run",
+    "JUnit.MachineBasicBlockTest.getPhiUses.executor": "Run",
+    "JUnit.ParserTest.parseBinaryExpression.executor": "Debug",
+    "JUnit.ParserTest.parseIfStatement.executor": "Run",
+    "JUnit.ParserTest.parseIfStatementSemicolons.executor": "Run",
+    "JUnit.ParserTest.parseProgram.executor": "Run",
+    "JUnit.ParserTest.parseWhileStatement.executor": "Run",
+    "JUnit.RangeTest.executor": "Run",
+    "JUnit.RangeTest.overlaps.executor": "Run",
+    "JUnit.SSADAGTest.postorder.executor": "Run",
+    "JUnit.ThreeAddressCodeTest.normalize.executor": "Run",
+    "JUnit.UniqueRenamerTest.executor": "Run",
+    "Maven.baby-pascal [clean,compile,exec:java].executor": "Run",
+    "Maven.baby-pascal [clean].executor": "Run",
+    "Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor": "Run",
+    "Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor": "Run",
+    "Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor": "Run",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "git-widget-placeholder": "linked__machine__instructions",
+    "ignore.preview.features.used": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/home/d/Documents/mirrored/baby-pascal",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.2",
+    "settings.editor.selected.configurable": "editor.preferences.tabs"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="com.d_m.ast" />
@@ -234,6 +252,44 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <configuration name="CodegenTest" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="baby-pascal" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="com.d_m.select.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="com.d_m.select" />
+      <option name="MAIN_CLASS_NAME" value="com.d_m.select.CodegenTest" />
+      <option name="METHOD_NAME" value="" />
+      <option name="TEST_OBJECT" value="class" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="wholeProject" />
+      </option>
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="CodegenTest.codegenAARCH" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="baby-pascal" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="com.d_m.select.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="com.d_m.select" />
+      <option name="MAIN_CLASS_NAME" value="com.d_m.select.CodegenTest" />
+      <option name="METHOD_NAME" value="codegenAARCH" />
+      <option name="TEST_OBJECT" value="method" />
+      <option name="TEST_SEARCH_SCOPE">
+        <value defaultName="wholeProject" />
+      </option>
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
     <configuration name="LinearScanTest.scanAARCH64" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="baby-pascal" />
       <extension name="coverage">
@@ -266,56 +322,21 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="ParserTest.parseIfStatementSemicolons" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+    <configuration name="RangeTest" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="baby-pascal" />
       <extension name="coverage">
         <pattern>
-          <option name="PATTERN" value="com.d_m.parser.*" />
+          <option name="PATTERN" value="com.d_m.regalloc.linear.*" />
           <option name="ENABLED" value="true" />
         </pattern>
       </extension>
-      <option name="PACKAGE_NAME" value="com.d_m.parser" />
-      <option name="MAIN_CLASS_NAME" value="com.d_m.parser.ParserTest" />
-      <option name="METHOD_NAME" value="parseIfStatementSemicolons" />
-      <option name="TEST_OBJECT" value="method" />
+      <option name="PACKAGE_NAME" value="com.d_m.regalloc.linear" />
+      <option name="MAIN_CLASS_NAME" value="com.d_m.regalloc.linear.RangeTest" />
+      <option name="METHOD_NAME" value="" />
+      <option name="TEST_OBJECT" value="class" />
       <option name="TEST_SEARCH_SCOPE">
         <value defaultName="wholeProject" />
       </option>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
-    </configuration>
-    <configuration name="ParserTest.parseProgram" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
-      <module name="baby-pascal" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="com.d_m.parser.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <option name="PACKAGE_NAME" value="com.d_m.parser" />
-      <option name="MAIN_CLASS_NAME" value="com.d_m.parser.ParserTest" />
-      <option name="METHOD_NAME" value="parseProgram" />
-      <option name="TEST_OBJECT" value="method" />
-      <option name="TEST_SEARCH_SCOPE">
-        <value defaultName="wholeProject" />
-      </option>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
-    </configuration>
-    <configuration name="ParserTest.parseWhileStatement" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
-      <module name="baby-pascal" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="com.d_m.parser.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <option name="PACKAGE_NAME" value="com.d_m.parser" />
-      <option name="MAIN_CLASS_NAME" value="com.d_m.parser.ParserTest" />
-      <option name="METHOD_NAME" value="parseWhileStatement" />
-      <option name="TEST_OBJECT" value="method" />
       <method v="2">
         <option name="Make" enabled="true" />
       </method>
@@ -328,19 +349,19 @@
       <item itemvalue="Application.GenX86_64" />
       <item itemvalue="Application.GenAARCH64" />
       <item itemvalue="JUnit.All tests" />
+      <item itemvalue="JUnit.CodegenTest" />
+      <item itemvalue="JUnit.CodegenTest.codegenAARCH" />
+      <item itemvalue="JUnit.RangeTest" />
       <item itemvalue="JUnit.LinearScanTest.scanAARCH64" />
       <item itemvalue="JUnit.LinearScanTest.scanX86" />
-      <item itemvalue="JUnit.ParserTest.parseIfStatementSemicolons" />
-      <item itemvalue="JUnit.ParserTest.parseProgram" />
-      <item itemvalue="JUnit.ParserTest.parseWhileStatement" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="JUnit.CodegenTest" />
+        <item itemvalue="JUnit.CodegenTest.codegenAARCH" />
+        <item itemvalue="JUnit.RangeTest" />
         <item itemvalue="JUnit.LinearScanTest.scanAARCH64" />
         <item itemvalue="JUnit.LinearScanTest.scanX86" />
-        <item itemvalue="JUnit.ParserTest.parseIfStatementSemicolons" />
-        <item itemvalue="JUnit.ParserTest.parseProgram" />
-        <item itemvalue="JUnit.ParserTest.parseWhileStatement" />
       </list>
     </recent_temporary>
   </component>
@@ -352,14 +373,6 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1709911294056</updated>
-    </task>
-    <task id="LOCAL-00209" summary="MachineBasicBlock remembers terminator and parallel moves are inserted before terminator">
-      <option name="closed" value="true" />
-      <created>1729864675284</created>
-      <option name="number" value="00209" />
-      <option name="presentableId" value="LOCAL-00209" />
-      <option name="project" value="LOCAL" />
-      <updated>1729864675285</updated>
     </task>
     <task id="LOCAL-00210" summary="Attempt modification to liveness equations to handle phi nodes">
       <option name="closed" value="true" />
@@ -745,7 +758,15 @@
       <option name="project" value="LOCAL" />
       <updated>1752875013886</updated>
     </task>
-    <option name="localTasksCounter" value="258" />
+    <task id="LOCAL-00258" summary="Fix expect test output">
+      <option name="closed" value="true" />
+      <created>1752965697472</created>
+      <option name="number" value="00258" />
+      <option name="presentableId" value="LOCAL-00258" />
+      <option name="project" value="LOCAL" />
+      <updated>1752965697472</updated>
+    </task>
+    <option name="localTasksCounter" value="259" />
     <servers />
   </component>
   <component name="UnknownFeatures">
@@ -753,7 +774,6 @@
     <option featureType="com.intellij.fileTypeFactory" implementationName="*.rule" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Fix accidental rewriting of fixed registers with stack slots" />
     <MESSAGE value="Writes stack slots in assembly" />
     <MESSAGE value="Use temporary register as middleman for moves between two memory operands" />
     <MESSAGE value="Start baby pascal scanner and parser" />
@@ -778,7 +798,8 @@
     <MESSAGE value="Cleanup instructions with memory operands (with special handling for movs) for AARCH64" />
     <MESSAGE value="Abstract out backend isa specific stuff into a Compiler interface" />
     <MESSAGE value="Build examples with AARCH64 and set up build scripts for AARCH64" />
-    <option name="LAST_COMMIT_MESSAGE" value="Build examples with AARCH64 and set up build scripts for AARCH64" />
+    <MESSAGE value="Fix expect test output" />
+    <option name="LAST_COMMIT_MESSAGE" value="Fix expect test output" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -791,7 +812,7 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
           <url>file://$PROJECT_DIR$/src/main/java/com/d_m/select/DAGTile.java</url>
-          <line>57</line>
+          <line>58</line>
           <option name="timeStamp" value="74" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
@@ -804,6 +825,11 @@
           <url>file://$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/LinearScan.java</url>
           <line>46</line>
           <option name="timeStamp" value="171" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java</url>
+          <line>75</line>
+          <option name="timeStamp" value="191" />
         </line-breakpoint>
         <breakpoint type="java-exception">
           <properties class="java.lang.NullPointerException" package="java.lang">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,15 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList">
+    <list default="true" id="b4a611aa-440b-4a2d-be05-a0aea4955c6b" name="Changes" comment="Better encapsulate ListWrapper fields">
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/d_m/ssa/ListWrapperTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/pass/ConstantPropagation.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/pass/ConstantPropagation.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/select/instr/MachineBasicBlock.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Block.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Block.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/Instruction.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/LinkedIterator.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ListWrapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/com/d_m/ssa/BlockTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/d_m/ssa/BlockTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -25,9 +23,9 @@
       <list>
         <option value="Enum" />
         <option value="Record" />
-        <option value="JUnit5 Test Class" />
         <option value="Interface" />
         <option value="Class" />
+        <option value="JUnit5 Test Class" />
       </list>
     </option>
   </component>
@@ -48,62 +46,65 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Application.Fibonacci.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FibonacciAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FibonacciX86_64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Funswap.executor&quot;: &quot;Run&quot;,
-    &quot;Application.FunswapAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Gen.executor&quot;: &quot;Run&quot;,
-    &quot;Application.GenAARCH64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.GenX86_64.executor&quot;: &quot;Run&quot;,
-    &quot;Application.Main.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.All tests.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BlockTest.createBlocks.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BlockTest.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.BuilderTest.convertFunction.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.CodegenTest.codegenAARCH.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.CodegenTest.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.DataflowTest.genKill.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.DataflowTest.genKillAndLiveness.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.IntervalTest.addRange.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.LengauerTarjanTest.idom.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.LinearScanTest.scanAARCH64.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.LinearScanTest.scanX86.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.MachineBasicBlockTest.addBeforeTerminator.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.MachineBasicBlockTest.getPhiUses.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseBinaryExpression.executor&quot;: &quot;Debug&quot;,
-    &quot;JUnit.ParserTest.parseIfStatement.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseIfStatementSemicolons.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseProgram.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ParserTest.parseWhileStatement.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.RangeTest.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.RangeTest.overlaps.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.SSADAGTest.postorder.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.ThreeAddressCodeTest.normalize.executor&quot;: &quot;Run&quot;,
-    &quot;JUnit.UniqueRenamerTest.executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [clean,compile,exec:java].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [clean].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor&quot;: &quot;Run&quot;,
-    &quot;Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;linked__machine__instructions&quot;,
-    &quot;ignore.preview.features.used&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/home/d/Documents/mirrored/baby-pascal&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;editor.preferences.tabs&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Application.Fibonacci.executor": "Run",
+    "Application.FibonacciAARCH64.executor": "Run",
+    "Application.FibonacciX86_64.executor": "Run",
+    "Application.Funswap.executor": "Run",
+    "Application.FunswapAARCH64.executor": "Run",
+    "Application.FunswapX86_64.executor": "Run",
+    "Application.Gen.executor": "Run",
+    "Application.GenAARCH64.executor": "Run",
+    "Application.GenX86_64.executor": "Run",
+    "Application.Main.executor": "Run",
+    "JUnit.All tests.executor": "Run",
+    "JUnit.BlockTest.createBlocks.executor": "Run",
+    "JUnit.BlockTest.executor": "Run",
+    "JUnit.BuilderTest.convertFunction.executor": "Debug",
+    "JUnit.CodegenTest.codegenAARCH.executor": "Run",
+    "JUnit.CodegenTest.executor": "Run",
+    "JUnit.DataflowTest.genKill.executor": "Run",
+    "JUnit.DataflowTest.genKillAndLiveness.executor": "Run",
+    "JUnit.IntervalTest.addRange.executor": "Run",
+    "JUnit.LengauerTarjanTest.idom.executor": "Run",
+    "JUnit.LinearScanTest.scanAARCH64.executor": "Debug",
+    "JUnit.LinearScanTest.scanX86.executor": "Debug",
+    "JUnit.ListWrapperTest.append.executor": "Run",
+    "JUnit.ListWrapperTest.reversed.executor": "Run",
+    "JUnit.MachineBasicBlockTest.addBeforeTerminator.executor": "Run",
+    "JUnit.MachineBasicBlockTest.getPhiUses.executor": "Run",
+    "JUnit.ParserTest.parseBinaryExpression.executor": "Debug",
+    "JUnit.ParserTest.parseIfStatement.executor": "Run",
+    "JUnit.ParserTest.parseIfStatementSemicolons.executor": "Run",
+    "JUnit.ParserTest.parseProgram.executor": "Run",
+    "JUnit.ParserTest.parseWhileStatement.executor": "Run",
+    "JUnit.RangeTest.executor": "Run",
+    "JUnit.RangeTest.overlaps.executor": "Run",
+    "JUnit.SSADAGTest.postorder.executor": "Run",
+    "JUnit.ThreeAddressCodeTest.normalize.executor": "Run",
+    "JUnit.UniqueRenamerTest.executor": "Run",
+    "Maven.baby-pascal [clean,compile,exec:java].executor": "Run",
+    "Maven.baby-pascal [clean].executor": "Run",
+    "Maven.baby-pascal [org.apache.maven.plugins:maven-clean-plugin:3.2.0:clean].executor": "Run",
+    "Maven.baby-pascal [org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile].executor": "Run",
+    "Maven.baby-pascal [org.codehaus.mojo:exec-maven-plugin:3.1.0:java].executor": "Run",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "git-widget-placeholder": "linked__machine__instructions",
+    "ignore.preview.features.used": "true",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "/home/d/Documents/mirrored/baby-pascal",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.2",
+    "settings.editor.selected.configurable": "editor.preferences.tabs"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="com.d_m.ast" />
@@ -129,11 +130,11 @@
       <recent name="com.d_m.code.normalize" />
     </key>
     <key name="CreateTestDialog.RecentsKey">
+      <recent name="com.d_m.ssa" />
       <recent name="com.d_m.parser" />
       <recent name="com.d_m.regalloc.linear" />
       <recent name="com.d_m.select.instr" />
       <recent name="com.d_m.deconstruct" />
-      <recent name="com.d_m.select.dag" />
     </key>
     <key name="CopyClassDialog.RECENTS_KEY">
       <recent name="com.d_m.select.instr" />
@@ -281,33 +282,33 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="LinearScanTest.scanAARCH64" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+    <configuration name="ListWrapperTest.append" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="baby-pascal" />
       <extension name="coverage">
         <pattern>
-          <option name="PATTERN" value="com.d_m.regalloc.linear.*" />
+          <option name="PATTERN" value="com.d_m.ssa.*" />
           <option name="ENABLED" value="true" />
         </pattern>
       </extension>
-      <option name="PACKAGE_NAME" value="com.d_m.regalloc.linear" />
-      <option name="MAIN_CLASS_NAME" value="com.d_m.regalloc.linear.LinearScanTest" />
-      <option name="METHOD_NAME" value="scanAARCH64" />
+      <option name="PACKAGE_NAME" value="com.d_m.ssa" />
+      <option name="MAIN_CLASS_NAME" value="com.d_m.ssa.ListWrapperTest" />
+      <option name="METHOD_NAME" value="append" />
       <option name="TEST_OBJECT" value="method" />
       <method v="2">
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="LinearScanTest.scanX86" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+    <configuration name="ListWrapperTest.reversed" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
       <module name="baby-pascal" />
       <extension name="coverage">
         <pattern>
-          <option name="PATTERN" value="com.d_m.regalloc.linear.*" />
+          <option name="PATTERN" value="com.d_m.ssa.*" />
           <option name="ENABLED" value="true" />
         </pattern>
       </extension>
-      <option name="PACKAGE_NAME" value="com.d_m.regalloc.linear" />
-      <option name="MAIN_CLASS_NAME" value="com.d_m.regalloc.linear.LinearScanTest" />
-      <option name="METHOD_NAME" value="scanX86" />
+      <option name="PACKAGE_NAME" value="com.d_m.ssa" />
+      <option name="MAIN_CLASS_NAME" value="com.d_m.ssa.ListWrapperTest" />
+      <option name="METHOD_NAME" value="reversed" />
       <option name="TEST_OBJECT" value="method" />
       <method v="2">
         <option name="Make" enabled="true" />
@@ -340,19 +341,19 @@
       <item itemvalue="Application.GenX86_64" />
       <item itemvalue="Application.GenAARCH64" />
       <item itemvalue="JUnit.All tests" />
+      <item itemvalue="JUnit.ListWrapperTest.append" />
+      <item itemvalue="JUnit.ListWrapperTest.reversed" />
       <item itemvalue="JUnit.CodegenTest" />
       <item itemvalue="JUnit.CodegenTest.codegenAARCH" />
       <item itemvalue="JUnit.RangeTest" />
-      <item itemvalue="JUnit.LinearScanTest.scanAARCH64" />
-      <item itemvalue="JUnit.LinearScanTest.scanX86" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="JUnit.ListWrapperTest.reversed" />
+        <item itemvalue="JUnit.ListWrapperTest.append" />
         <item itemvalue="JUnit.CodegenTest" />
         <item itemvalue="JUnit.CodegenTest.codegenAARCH" />
         <item itemvalue="JUnit.RangeTest" />
-        <item itemvalue="JUnit.LinearScanTest.scanAARCH64" />
-        <item itemvalue="JUnit.LinearScanTest.scanX86" />
       </list>
     </recent_temporary>
   </component>
@@ -364,14 +365,6 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1709911294056</updated>
-    </task>
-    <task id="LOCAL-00211" summary="Add unit tests for getPhiUses() and getPhiDefs()">
-      <option name="closed" value="true" />
-      <created>1729957035450</created>
-      <option name="number" value="00211" />
-      <option name="presentableId" value="LOCAL-00211" />
-      <option name="project" value="LOCAL" />
-      <updated>1729957035450</updated>
     </task>
     <task id="LOCAL-00212" summary="Small fixes to linear scan so that it assigns registers">
       <option name="closed" value="true" />
@@ -757,7 +750,15 @@
       <option name="project" value="LOCAL" />
       <updated>1753039713658</updated>
     </task>
-    <option name="localTasksCounter" value="260" />
+    <task id="LOCAL-00260" summary="Better encapsulate ListWrapper fields">
+      <option name="closed" value="true" />
+      <created>1753110876488</created>
+      <option name="number" value="00260" />
+      <option name="presentableId" value="LOCAL-00260" />
+      <option name="project" value="LOCAL" />
+      <updated>1753110876488</updated>
+    </task>
+    <option name="localTasksCounter" value="261" />
     <servers />
   </component>
   <component name="UnknownFeatures">
@@ -765,7 +766,6 @@
     <option featureType="com.intellij.fileTypeFactory" implementationName="*.rule" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Use temporary register as middleman for moves between two memory operands" />
     <MESSAGE value="Start baby pascal scanner and parser" />
     <MESSAGE value="Parse types and typed names" />
     <MESSAGE value="More parsing for function declarations and statements" />
@@ -790,7 +790,8 @@
     <MESSAGE value="Build examples with AARCH64 and set up build scripts for AARCH64" />
     <MESSAGE value="Fix expect test output" />
     <MESSAGE value="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList" />
-    <option name="LAST_COMMIT_MESSAGE" value="Convert MachineInstructions in MachineBasicBlock to use linked representation instead of ArrayList" />
+    <MESSAGE value="Better encapsulate ListWrapper fields" />
+    <option name="LAST_COMMIT_MESSAGE" value="Better encapsulate ListWrapper fields" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
@@ -816,11 +817,6 @@
           <url>file://$PROJECT_DIR$/src/main/java/com/d_m/regalloc/linear/LinearScan.java</url>
           <line>46</line>
           <option name="timeStamp" value="171" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java</url>
-          <line>75</line>
-          <option name="timeStamp" value="191" />
         </line-breakpoint>
         <breakpoint type="java-exception">
           <properties class="java.lang.NullPointerException" package="java.lang">

--- a/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java
+++ b/src/main/java/com/d_m/deconstruct/SequentializeParallelMoves.java
@@ -4,8 +4,8 @@ import com.d_m.select.FunctionLoweringInfo;
 import com.d_m.select.instr.*;
 import com.d_m.select.reg.Register;
 import com.d_m.select.reg.RegisterConstraint;
+import com.d_m.ssa.ListWrapper;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,7 +35,7 @@ public class SequentializeParallelMoves {
     }
 
     public static void sequentializeBlock(FunctionLoweringInfo info, Register.Physical tmp, MachineBasicBlock block) {
-        List<MachineInstruction> newInstructions = new ArrayList<>(block.getInstructions().size());
+        ListWrapper<MachineInstruction> newInstructions = new ListWrapper<>();
         Emitter emitter = new Emitter() {
             @Override
             public MachineOperand makeTmp(Register.Physical register) {
@@ -44,7 +44,7 @@ public class SequentializeParallelMoves {
 
             @Override
             public void emitMove(MachineOperand destination, MachineOperand source) {
-                newInstructions.add(info.isa.createMoveInstruction(destination, source));
+                newInstructions.addToEnd(info.isa.createMoveInstruction(destination, source));
             }
         };
         for (MachineInstruction instruction : block.getInstructions()) {
@@ -52,7 +52,7 @@ public class SequentializeParallelMoves {
                 SequentializeParallelMoves sequentialize = new SequentializeParallelMoves(tmp, instruction.getOperands(), emitter);
                 sequentialize.sequentialize();
             } else {
-                newInstructions.add(instruction);
+                newInstructions.addToEnd(instruction);
             }
         }
         block.setInstructions(newInstructions);

--- a/src/main/java/com/d_m/pass/ConstantPropagation.java
+++ b/src/main/java/com/d_m/pass/ConstantPropagation.java
@@ -127,8 +127,8 @@ public class ConstantPropagation extends BooleanFunctionPass {
 
     private boolean isEmptyBlock(Block block) {
         return !block.getPredecessors().isEmpty() &&
-                (block.getInstructions().first == null ||
-                        (block.getInstructions().first == block.getInstructions().last &&
+                (block.getInstructions().getFirst() == null ||
+                        (block.getInstructions().getFirst() == block.getInstructions().getLast() &&
                                 block.getSuccessors().size() == 1));
     }
 

--- a/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java
+++ b/src/main/java/com/d_m/regalloc/common/CleanupAssembly.java
@@ -2,10 +2,10 @@ package com.d_m.regalloc.common;
 
 import com.d_m.select.instr.*;
 import com.d_m.select.reg.Register;
+import com.d_m.ssa.LinkedIterator;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
 public class CleanupAssembly {
@@ -34,7 +34,7 @@ public class CleanupAssembly {
 
     public static void expandMovesBetweenMemoryOperands(MachineFunction function, Register.Physical temp) {
         for (MachineBasicBlock block : function.getBlocks()) {
-            var it = block.getInstructions().listIterator();
+            var it = block.getInstructions().linkedIterator();
             while (it.hasNext()) {
                 MachineInstruction instruction = it.next();
                 if (instruction.getInstruction().equals("mov") && allMemoryOperands(instruction)) {
@@ -69,7 +69,7 @@ public class CleanupAssembly {
     /// @param temps    temporary registers used for expanding memory operations
     public static void expandInstructionsWithMemoryOperands(MachineFunction function, Set<Register.Physical> temps) {
         for (MachineBasicBlock block : function.getBlocks()) {
-            var it = block.getInstructions().listIterator();
+            var it = block.getInstructions().linkedIterator();
             while (it.hasNext()) {
                 MachineInstruction instruction = it.next();
                 if (anyMemoryOperands(instruction)) {
@@ -84,7 +84,7 @@ public class CleanupAssembly {
         }
     }
 
-    private static void expandMoveInstruction(MachineInstruction instruction, ListIterator<MachineInstruction> it, Set<Register.Physical> temps) {
+    private static void expandMoveInstruction(MachineInstruction instruction, LinkedIterator<MachineInstruction> it, Set<Register.Physical> temps) {
         MachineOperandPair firstOperand = instruction.getOperands().get(0);
         MachineOperandPair secondOperand = instruction.getOperands().get(1);
         if (firstOperand.isMemoryOperand() && secondOperand.isMemoryOperand()) {
@@ -114,7 +114,7 @@ public class CleanupAssembly {
         }
     }
 
-    private static void expandNormalInstruction(MachineInstruction instruction, ListIterator<MachineInstruction> it, Set<Register.Physical> temps) {
+    private static void expandNormalInstruction(MachineInstruction instruction, LinkedIterator<MachineInstruction> it, Set<Register.Physical> temps) {
         var tempIterator = temps.iterator();
         for (int i = 0; i < instruction.getOperands().size(); i++) {
             MachineOperandPair pair = instruction.getOperands().get(i);

--- a/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java
+++ b/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java
@@ -42,7 +42,7 @@ public class BuildIntervals {
             if (operand instanceof MachineOperand.Register(Register.Virtual(int n, _, RegisterConstraint constraint))) {
                 // If the virtual register was a constrained function argument register,
                 // then set its instruction to be the first instruction in the entry block of the function.
-                virtualRegisterToMachineInstructionMap.put(n, function.getBlocks().getFirst().getInstructions().getFirst());
+                virtualRegisterToMachineInstructionMap.put(n, function.getBlocks().getFirst().getInstructions().first);
                 if (constraint instanceof RegisterConstraint.UsePhysical(Register.Physical register)) {
                     functionParamToPhysicalMap.put(n, register);
                 }
@@ -95,7 +95,7 @@ public class BuildIntervals {
         while (it.hasNext()) {
             int virtualRegister = it.next();
             MachineInstruction instruction = virtualRegisterToMachineInstructionMap.get(virtualRegister);
-            addRange(virtualRegister, instruction, block, numbering.getInstructionNumber(block.getInstructions().getLast()) + 1);
+            addRange(virtualRegister, instruction, block, numbering.getInstructionNumber(block.getInstructions().last) + 1);
         }
         for (MachineInstruction instruction : block.getInstructions().reversed()) {
             for (MachineOperandPair pair : instruction.getOperands()) {
@@ -137,8 +137,8 @@ public class BuildIntervals {
 
     public void addRange(int virtualRegister, MachineInstruction i, MachineBasicBlock b, int end) {
         int ni = numbering.getInstructionNumber(i);
-        int nbf = numbering.getInstructionNumber(b.getInstructions().getFirst());
-        int nbl = numbering.getInstructionNumber(b.getInstructions().getLast());
+        int nbf = numbering.getInstructionNumber(b.getInstructions().first);
+        int nbl = numbering.getInstructionNumber(b.getInstructions().last);
         int start = ni >= nbf && ni <= nbl ? ni : nbf;
         // The numbering for function parameter virtual registers is always the very first instruction,
         // which doesn't contain the register. In that case, use the mapping to find the physical register.

--- a/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java
+++ b/src/main/java/com/d_m/regalloc/linear/BuildIntervals.java
@@ -42,7 +42,7 @@ public class BuildIntervals {
             if (operand instanceof MachineOperand.Register(Register.Virtual(int n, _, RegisterConstraint constraint))) {
                 // If the virtual register was a constrained function argument register,
                 // then set its instruction to be the first instruction in the entry block of the function.
-                virtualRegisterToMachineInstructionMap.put(n, function.getBlocks().getFirst().getInstructions().first);
+                virtualRegisterToMachineInstructionMap.put(n, function.getBlocks().getFirst().getInstructions().getFirst());
                 if (constraint instanceof RegisterConstraint.UsePhysical(Register.Physical register)) {
                     functionParamToPhysicalMap.put(n, register);
                 }
@@ -95,7 +95,7 @@ public class BuildIntervals {
         while (it.hasNext()) {
             int virtualRegister = it.next();
             MachineInstruction instruction = virtualRegisterToMachineInstructionMap.get(virtualRegister);
-            addRange(virtualRegister, instruction, block, numbering.getInstructionNumber(block.getInstructions().last) + 1);
+            addRange(virtualRegister, instruction, block, numbering.getInstructionNumber(block.getInstructions().getLast()) + 1);
         }
         for (MachineInstruction instruction : block.getInstructions().reversed()) {
             for (MachineOperandPair pair : instruction.getOperands()) {
@@ -137,8 +137,8 @@ public class BuildIntervals {
 
     public void addRange(int virtualRegister, MachineInstruction i, MachineBasicBlock b, int end) {
         int ni = numbering.getInstructionNumber(i);
-        int nbf = numbering.getInstructionNumber(b.getInstructions().first);
-        int nbl = numbering.getInstructionNumber(b.getInstructions().last);
+        int nbf = numbering.getInstructionNumber(b.getInstructions().getFirst());
+        int nbl = numbering.getInstructionNumber(b.getInstructions().getLast());
         int start = ni >= nbf && ni <= nbl ? ni : nbf;
         // The numbering for function parameter virtual registers is always the very first instruction,
         // which doesn't contain the register. In that case, use the mapping to find the physical register.

--- a/src/main/java/com/d_m/select/Codegen.java
+++ b/src/main/java/com/d_m/select/Codegen.java
@@ -123,7 +123,7 @@ public class Codegen {
             MachineBasicBlock machineBlock = new MachineBasicBlock(machineFunction);
             // Add the parallel move from constrained virtual registers -> unconstrained virtual registers into the function's entry block.
             if (block.equals(block.getEntry()) && !functionEntryMove.getOperands().isEmpty()) {
-                machineBlock.getInstructions().add(functionEntryMove);
+                machineBlock.getInstructions().addToEnd(functionEntryMove);
             }
             SSADAG dag = new SSADAG(functionLoweringInfo, block);
             machineFunction.addBlock(machineBlock);
@@ -170,7 +170,7 @@ public class Codegen {
         machineBlock.setPredecessors(block.getPredecessors().stream().map(blockMap::get).toList());
         machineBlock.setSuccessors(block.getSuccessors().stream().map(blockMap::get).toList());
 
-        List<MachineInstruction> terminator = new ArrayList<>();
+        ListWrapper<MachineInstruction> terminator = new ListWrapper<>();
         // For each tile, go bottom up emitting the code and marking the node
         // with the machine operand result. if a node's result has already been computed,
         // skip it.
@@ -178,7 +178,7 @@ public class Codegen {
             bottomUpEmit(info, machineBlock, tileMapping, emitResultMapping, terminator, tile);
         }
         machineBlock.setTerminator();
-        machineBlock.getInstructions().addAll(terminator);
+        machineBlock.getInstructions().append(terminator);
     }
 
     public MachineFunction getFunction(Function function) {
@@ -193,7 +193,7 @@ public class Codegen {
                                           MachineBasicBlock block,
                                           Map<Value, DAGTile> tileMapping,
                                           Map<Value, MachineOperand[]> emitResultMapping,
-                                          List<MachineInstruction> terminator,
+                                          ListWrapper<MachineInstruction> terminator,
                                           DAGTile tile) {
         if (emitResultMapping.containsKey(tile.root())) {
             return emitResultMapping.get(tile.root());

--- a/src/main/java/com/d_m/select/DAGTile.java
+++ b/src/main/java/com/d_m/select/DAGTile.java
@@ -6,6 +6,7 @@ import com.d_m.select.reg.Register;
 import com.d_m.select.reg.RegisterClass;
 import com.d_m.select.reg.RegisterConstraint;
 import com.d_m.ssa.Instruction;
+import com.d_m.ssa.ListWrapper;
 import com.d_m.ssa.Value;
 
 import java.util.*;
@@ -62,10 +63,10 @@ public class DAGTile implements Tile<Value>, Comparable<DAGTile> {
     public MachineOperand[] emit(FunctionLoweringInfo info,
                                  MachineBasicBlock block,
                                  List<MachineOperand[]> arguments,
-                                 List<MachineInstruction> terminator) {
+                                 ListWrapper<MachineInstruction> terminator) {
         Map<String, MachineOperand> constrainedRegisterMap = new HashMap<>();
         Map<Integer, MachineOperand> tempRegisterMap = new HashMap<>();
-        List<MachineInstruction> emitter = block.getInstructions();
+        ListWrapper<MachineInstruction> emitter = block.getInstructions();
         for (com.d_m.gen.Instruction instruction : rule.getCode().instructions()) {
             if (instruction.name().equals("terminator")) {
                 terminator.clear();
@@ -85,7 +86,7 @@ public class DAGTile implements Tile<Value>, Comparable<DAGTile> {
                     MachineBasicBlock successor = successors.get(i);
                     List<MachineOperandPair> operands = List.of(new MachineOperandPair(new MachineOperand.BasicBlock(successor), MachineOperandKind.USE));
                     MachineInstruction converted = new MachineInstruction(i == 0 ? instruction.name() : info.isa.jumpOp(), operands);
-                    emitter.add(converted);
+                    emitter.addToEnd(converted);
                 }
             } else {
                 boolean validInstruction = true;
@@ -102,7 +103,7 @@ public class DAGTile implements Tile<Value>, Comparable<DAGTile> {
                 // For example: a phi node with side effect tokens as its operands.
                 if (validInstruction) {
                     MachineInstruction converted = new MachineInstruction(instruction.name(), operands);
-                    emitter.add(converted);
+                    emitter.addToEnd(converted);
                 }
             }
         }

--- a/src/main/java/com/d_m/select/SSADAG.java
+++ b/src/main/java/com/d_m/select/SSADAG.java
@@ -194,8 +194,7 @@ public class SSADAG implements DAG<Value> {
 
     private void calculate() {
         Set<Value> visited = new HashSet<>();
-        for (var it = block.getInstructions().reversed(); it.hasNext(); ) {
-            Instruction instruction = it.next();
+        for (Instruction instruction : block.getInstructions().reversed()) {
             if (!visited.contains(instruction)) {
                 roots.add(instruction);
             }

--- a/src/main/java/com/d_m/select/instr/MachineBasicBlock.java
+++ b/src/main/java/com/d_m/select/instr/MachineBasicBlock.java
@@ -4,6 +4,7 @@ import com.d_m.cfg.BlockLiveness;
 import com.d_m.cfg.BlockLivenessInfo;
 import com.d_m.cfg.IBlock;
 import com.d_m.select.reg.Register;
+import com.d_m.ssa.ListWrapper;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -17,9 +18,9 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
     private List<MachineBasicBlock> predecessors;
     private List<MachineBasicBlock> successors;
 
-    private List<MachineInstruction> instructions;
+    private ListWrapper<MachineInstruction> instructions;
     private int dominatorTreeLevel;
-    private int terminatorIndex;
+    private MachineInstruction instBeforeTerminator;
     private MachineBasicBlock entry;
     private MachineBasicBlock exit;
     private MachineGenKillInfo info;
@@ -28,9 +29,9 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
 
     public MachineBasicBlock(MachineFunction parent) {
         this.parent = parent;
-        instructions = new ArrayList<>();
+        instructions = new ListWrapper<>();
         dominatorTreeLevel = -1;
-        terminatorIndex = -1;
+        instBeforeTerminator = null;
         predecessors = new ArrayList<>();
         successors = new ArrayList<>();
         entry = null;
@@ -45,8 +46,12 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
         info = new MachineGenKillInfo(this.instructions);
     }
 
-    public List<MachineInstruction> getInstructions() {
+    public ListWrapper<MachineInstruction> getInstructions() {
         return instructions;
+    }
+
+    public void setInstructions(ListWrapper<MachineInstruction> newInstructions) {
+        this.instructions = newInstructions;
     }
 
     public List<MachineBasicBlock> getPredecessors() {
@@ -65,10 +70,6 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
     @Override
     public void setDominatorTreeLevel(int level) {
         dominatorTreeLevel = level;
-    }
-
-    public void setInstructions(List<MachineInstruction> instructions) {
-        this.instructions = instructions;
     }
 
     public void setPredecessors(List<MachineBasicBlock> predecessors) {
@@ -125,21 +126,22 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
         this.entry = entry;
     }
 
-    protected int getTerminator() {
-        return terminatorIndex;
+    protected MachineInstruction getTerminator() {
+        return instBeforeTerminator != null ? instBeforeTerminator.getNext() : null;
     }
 
     public void setTerminator() {
-        terminatorIndex = instructions.size();
+        instBeforeTerminator = instructions.last;
     }
 
     public void addBeforeTerminator(MachineInstruction instruction) {
-        if (terminatorIndex == instructions.size()) {
-            instructions.add(instruction);
+        if (instBeforeTerminator == null) {
+            instBeforeTerminator = instruction;
+            instructions.addToEnd(instruction);
         } else {
-            instructions.add(terminatorIndex, instruction);
+            instructions.addAfter(instBeforeTerminator, instruction);
+            instBeforeTerminator = instruction;
         }
-        terminatorIndex++;
     }
 
     @Override

--- a/src/main/java/com/d_m/select/instr/MachineBasicBlock.java
+++ b/src/main/java/com/d_m/select/instr/MachineBasicBlock.java
@@ -131,7 +131,7 @@ public class MachineBasicBlock extends BlockLiveness<MachineBasicBlock> implemen
     }
 
     public void setTerminator() {
-        instBeforeTerminator = instructions.last;
+        instBeforeTerminator = instructions.getLast();
     }
 
     public void addBeforeTerminator(MachineInstruction instruction) {

--- a/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java
+++ b/src/main/java/com/d_m/select/instr/MachineGenKillInfo.java
@@ -1,6 +1,8 @@
 package com.d_m.select.instr;
 
 import com.d_m.select.reg.Register;
+import com.d_m.ssa.ListWrapper;
+import com.google.common.collect.Iterables;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -10,9 +12,10 @@ public class MachineGenKillInfo {
     public final BitSet genBlock;
     public final BitSet killBlock;
 
-    public MachineGenKillInfo(List<MachineInstruction> code) {
-        List<BitSet> gen = new ArrayList<>(code.size());
-        List<BitSet> kill = new ArrayList<>(code.size());
+    public MachineGenKillInfo(ListWrapper<MachineInstruction> code) {
+        int size = Iterables.size(code);
+        List<BitSet> gen = new ArrayList<>(size);
+        List<BitSet> kill = new ArrayList<>(size);
         for (MachineInstruction _ : code) {
             gen.add(new BitSet());
             kill.add(new BitSet());
@@ -21,8 +24,8 @@ public class MachineGenKillInfo {
         genBlock = new BitSet();
         killBlock = new BitSet();
 
-        for (int i = code.size() - 1; i >= 0; i--) {
-            MachineInstruction instruction = code.get(i);
+        int i = size - 1;
+        for (MachineInstruction instruction : code.reversed()) {
             // Ignore phi nodes for now since they have different liveness characteristics
             // than normal instructions.
             if (instruction.getInstruction().equals("phi")) {
@@ -41,6 +44,7 @@ public class MachineGenKillInfo {
             genBlock.or(gen.get(i));
             killBlock.andNot(gen.get(i));
             killBlock.or(kill.get(i));
+            i--;
         }
     }
 }

--- a/src/main/java/com/d_m/select/instr/MachineInstruction.java
+++ b/src/main/java/com/d_m/select/instr/MachineInstruction.java
@@ -2,6 +2,7 @@ package com.d_m.select.instr;
 
 import com.d_m.select.reg.Register;
 import com.d_m.select.reg.RegisterConstraint;
+import com.d_m.ssa.Listable;
 import com.d_m.util.Pair;
 
 import java.util.ArrayList;
@@ -9,7 +10,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 
-public class MachineInstruction {
+public class MachineInstruction implements Listable<MachineInstruction> {
     private final int id = IdGenerator.newId();
     private final String instruction;
     private final List<MachineOperandPair> operands;
@@ -17,6 +18,8 @@ public class MachineInstruction {
     private MachineInstruction join;
 
     private MachineBasicBlock parent;
+    private MachineInstruction prev;
+    private MachineInstruction next;
 
     public MachineInstruction(String instruction, List<MachineOperandPair> operands) {
         this.instruction = instruction;
@@ -72,6 +75,7 @@ public class MachineInstruction {
 
     /**
      * This should be called only after getReuseOperands() has been called once.
+     *
      * @param operandIndex the index of the operand in the instruction
      */
     public boolean isReusedOperand(int operandIndex) {
@@ -96,5 +100,25 @@ public class MachineInstruction {
                 "instruction='" + instruction + '\'' +
                 ", operands=" + operands +
                 '}';
+    }
+
+    @Override
+    public MachineInstruction getPrev() {
+        return prev;
+    }
+
+    @Override
+    public void setPrev(MachineInstruction prev) {
+        this.prev = prev;
+    }
+
+    @Override
+    public MachineInstruction getNext() {
+        return next;
+    }
+
+    @Override
+    public void setNext(MachineInstruction next) {
+        this.next = next;
     }
 }

--- a/src/main/java/com/d_m/ssa/Block.java
+++ b/src/main/java/com/d_m/ssa/Block.java
@@ -40,15 +40,11 @@ public class Block extends Constant implements IBlock<Block> {
     }
 
     public List<Block> getSuccessors() {
-        return instructions.last == null ? new ArrayList<>() : instructions.last.getSuccessors();
+        return instructions.getLast() == null ? new ArrayList<>() : instructions.getLast().getSuccessors();
     }
 
     public Instruction getTerminator() {
-        return instructions.last;
-    }
-
-    public void setTerminator(Instruction terminator) {
-        instructions.last = terminator;
+        return instructions.getLast();
     }
 
     @Override

--- a/src/main/java/com/d_m/ssa/Instruction.java
+++ b/src/main/java/com/d_m/ssa/Instruction.java
@@ -91,14 +91,6 @@ public class Instruction extends Value implements Listable<Instruction> {
         return use;
     }
 
-    public void addSuccessor(Block successor) {
-        successors.add(successor);
-    }
-
-    public void removeSuccessor(Block successor) {
-        successors.remove(successor);
-    }
-
     public List<Block> getSuccessors() {
         return successors;
     }

--- a/src/main/java/com/d_m/ssa/Instruction.java
+++ b/src/main/java/com/d_m/ssa/Instruction.java
@@ -67,21 +67,21 @@ public class Instruction extends Value implements Listable<Instruction> {
                 // Set the successors of the new terminator to the deleted instruction's successors.
                 prev.getSuccessors().clear();
                 prev.getSuccessors().addAll(this.getSuccessors());
-                parent.getInstructions().last = prev;
+                parent.getInstructions().setLast(prev);
             }
         }
         if (next != null) {
             next.prev = prev;
-            if (this.equals(parent.getInstructions().first)) {
-                parent.getInstructions().first = next;
+            if (this.equals(parent.getInstructions().getFirst())) {
+                parent.getInstructions().setFirst(next);
             }
         }
         // Delete if there is only a single instruction left in the block by creating a GOTO statement.
         if (prev == null && next == null) {
             Instruction gotoInstruction = new Instruction(null, null, Operator.GOTO, List.of());
             gotoInstruction.getSuccessors().addAll(this.getSuccessors());
-            parent.getInstructions().first = gotoInstruction;
-            parent.getInstructions().last = gotoInstruction;
+            parent.getInstructions().setFirst(gotoInstruction);
+            parent.getInstructions().setLast(gotoInstruction);
         }
     }
 

--- a/src/main/java/com/d_m/ssa/LinkedIterator.java
+++ b/src/main/java/com/d_m/ssa/LinkedIterator.java
@@ -36,6 +36,8 @@ public class LinkedIterator<T extends Listable<T>> implements Iterator<T> {
 
         if (prev.getNext() != null) {
             prev.getNext().setPrev(prev.getPrev());
+        } else if (setLast != null) {
+            setLast.accept(prev.getPrev());
         }
         if (prev.getPrev() != null) {
             prev.getPrev().setNext(prev.getNext());

--- a/src/main/java/com/d_m/ssa/LinkedIterator.java
+++ b/src/main/java/com/d_m/ssa/LinkedIterator.java
@@ -54,7 +54,7 @@ public class LinkedIterator<T extends Listable<T>> implements Iterator<T> {
         if (prev != null) {
             prev.setNext(node);
             node.setPrev(prev);
-        } else {
+        } else if (setHead != null) {
             setHead.accept(node);
         }
         node.setNext(curr);

--- a/src/main/java/com/d_m/ssa/LinkedIterator.java
+++ b/src/main/java/com/d_m/ssa/LinkedIterator.java
@@ -1,14 +1,19 @@
 package com.d_m.ssa;
 
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 public class LinkedIterator<T extends Listable<T>> implements Iterator<T> {
-    private T prev = null;
-    private T curr = null;
+    private T prev;
+    private T curr;
+    private final Consumer<T> setHead;
+    private final Consumer<T> setLast;
 
-    public LinkedIterator(T curr) {
+    public LinkedIterator(T curr, Consumer<T> setHead, Consumer<T> setLast) {
         this.prev = null;
         this.curr = curr;
+        this.setHead = setHead;
+        this.setLast = setLast;
     }
 
     @Override
@@ -34,7 +39,30 @@ public class LinkedIterator<T extends Listable<T>> implements Iterator<T> {
         }
         if (prev.getPrev() != null) {
             prev.getPrev().setNext(prev.getNext());
+        } else if (setHead != null) {
+            setHead.accept(prev.getNext());
         }
         prev = prev.getPrev();
+    }
+
+    /**
+     * Inserts specified element immediately before the element that would be returned by next().
+     *
+     * @param node
+     */
+    public void add(T node) {
+        if (prev != null) {
+            prev.setNext(node);
+            node.setPrev(prev);
+        } else {
+            setHead.accept(node);
+        }
+        node.setNext(curr);
+        if (curr != null) {
+            curr.setPrev(node);
+        } else if (setLast != null) {
+            setLast.accept(node);
+        }
+        prev = node;
     }
 }

--- a/src/main/java/com/d_m/ssa/ListWrapper.java
+++ b/src/main/java/com/d_m/ssa/ListWrapper.java
@@ -1,10 +1,21 @@
 package com.d_m.ssa;
 
+import com.google.common.collect.Iterables;
+
 import java.util.Iterator;
 
 public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
     public T first = null;
     public T last = null;
+
+    public void clear() {
+        this.first = null;
+        this.last = null;
+    }
+
+    public boolean contains(T node) {
+        return Iterables.contains(this, node);
+    }
 
     public void addToFront(T node) {
         node.setPrev(null);
@@ -25,6 +36,8 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
         add.setNext(next);
         if (next != null) {
             next.setPrev(add);
+        } else {
+            last = add;
         }
     }
 
@@ -35,6 +48,8 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
         add.setPrev(prev);
         if (prev != null) {
             prev.setNext(add);
+        } else {
+            first = add;
         }
     }
 
@@ -63,12 +78,28 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
         last = node;
     }
 
-    @Override
-    public Iterator<T> iterator() {
-        return new LinkedIterator<>(first);
+    public void append(ListWrapper<T> list) {
+        if (last == null) {
+            first = list.first;
+        } else {
+            last.setNext(list.first);
+            if (list.first != null) {
+                list.first.setPrev(last);
+            }
+        }
+        last = list.last;
     }
 
-    public Iterator<T> reversed() {
+    public LinkedIterator<T> linkedIterator() {
+        return new LinkedIterator<>(first, (T node) -> first = node, (T node) -> last = node);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return linkedIterator();
+    }
+
+    public ReverseLinkedIterator<T> reversed() {
         return new ReverseLinkedIterator<>(last);
     }
 }

--- a/src/main/java/com/d_m/ssa/ListWrapper.java
+++ b/src/main/java/com/d_m/ssa/ListWrapper.java
@@ -3,6 +3,9 @@ package com.d_m.ssa;
 import com.google.common.collect.Iterables;
 
 import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
     private T first = null;
@@ -69,20 +72,6 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
         }
     }
 
-    public void addBeforeLast(T node) {
-        if (last != null) {
-            if (last.getPrev() != null) {
-                last.getPrev().setNext(node);
-            }
-            node.setPrev(last.getPrev());
-            node.setNext(last);
-            last.setPrev(node);
-            if (last.equals(first)) {
-                first = node;
-            }
-        }
-    }
-
     public void addToEnd(T node) {
         if (last == null) {
             first = node;
@@ -103,7 +92,9 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
                 list.first.setPrev(last);
             }
         }
-        last = list.last;
+        if (list.last != null) {
+            last = list.last;
+        }
     }
 
     public LinkedIterator<T> linkedIterator() {
@@ -116,6 +107,15 @@ public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
     }
 
     public ReverseLinkedIterator<T> reversed() {
-        return new ReverseLinkedIterator<>(last);
+        return new ReverseLinkedIterator<>(last, (T node) -> first = node, (T node) -> last = node);
+    }
+
+    /**
+     * Converts a list wrapper to a list. Should only be used for testing.
+     *
+     * @return a list representation of the linked list.
+     */
+    public List<T> toList() {
+        return StreamSupport.stream(spliterator(), false).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/d_m/ssa/ListWrapper.java
+++ b/src/main/java/com/d_m/ssa/ListWrapper.java
@@ -5,8 +5,24 @@ import com.google.common.collect.Iterables;
 import java.util.Iterator;
 
 public class ListWrapper<T extends Listable<T>> implements Iterable<T> {
-    public T first = null;
-    public T last = null;
+    private T first = null;
+    private T last = null;
+
+    public T getFirst() {
+        return first;
+    }
+
+    public T getLast() {
+        return last;
+    }
+
+    void setFirst(T first) {
+        this.first = first;
+    }
+
+    void setLast(T last) {
+        this.last = last;
+    }
 
     public void clear() {
         this.first = null;

--- a/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java
+++ b/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java
@@ -2,7 +2,7 @@ package com.d_m.ssa;
 
 import java.util.Iterator;
 
-public class ReverseLinkedIterator<T extends Listable<T>> implements Iterator<T> {
+public class ReverseLinkedIterator<T extends Listable<T>> implements Iterator<T>, Iterable<T> {
     private T next = null;
     private T curr = null;
 
@@ -36,5 +36,10 @@ public class ReverseLinkedIterator<T extends Listable<T>> implements Iterator<T>
             next.getNext().setPrev(next.getPrev());
         }
         next = next.getNext();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this;
     }
 }

--- a/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java
+++ b/src/main/java/com/d_m/ssa/ReverseLinkedIterator.java
@@ -1,14 +1,19 @@
 package com.d_m.ssa;
 
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 public class ReverseLinkedIterator<T extends Listable<T>> implements Iterator<T>, Iterable<T> {
-    private T next = null;
-    private T curr = null;
+    private T next;
+    private T curr;
+    private final Consumer<T> setHead;
+    private final Consumer<T> setLast;
 
-    public ReverseLinkedIterator(T curr) {
+    public ReverseLinkedIterator(T curr, Consumer<T> setHead, Consumer<T> setLast) {
         this.next = null;
         this.curr = curr;
+        this.setHead = setHead;
+        this.setLast = setLast;
     }
 
     @Override
@@ -31,9 +36,13 @@ public class ReverseLinkedIterator<T extends Listable<T>> implements Iterator<T>
 
         if (next.getPrev() != null) {
             next.getPrev().setNext(next.getNext());
+        } else if (setHead != null) {
+            setHead.accept(next.getNext());
         }
         if (next.getNext() != null) {
             next.getNext().setPrev(next.getPrev());
+        } else if (setLast != null) {
+            setLast.accept(next.getPrev());
         }
         next = next.getNext();
     }

--- a/src/main/java/com/d_m/ssa/Value.java
+++ b/src/main/java/com/d_m/ssa/Value.java
@@ -58,7 +58,7 @@ public abstract class Value implements Comparable<Value> {
     private class UseIterable implements Iterable<Use> {
         @Override
         public Iterator<Use> iterator() {
-            return new LinkedIterator<>(uses);
+            return new LinkedIterator<>(uses, (Use use) -> uses = use, null);
         }
     }
 

--- a/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java
+++ b/src/test/java/com/d_m/deconstruct/InsertParallelMovesTest.java
@@ -201,8 +201,8 @@ class InsertParallelMovesTest {
                     jmp [l15,USE]
                   }
                   block l17 [l15] {
-                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%2r12,DEF], [%4r13,DEF], [%6r14,DEF], [%8r15,DEF], [%10rbx,DEF], [%12rsp,DEF], [%14rbp,DEF]
                     mov [%17any,USE], [%48rax,DEF]
+                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%2r12,DEF], [%4r13,DEF], [%6r14,DEF], [%8r15,DEF], [%10rbx,DEF], [%12rsp,DEF], [%14rbp,DEF]
                   }
                 }
                 """;

--- a/src/test/java/com/d_m/select/CodegenTest.java
+++ b/src/test/java/com/d_m/select/CodegenTest.java
@@ -165,8 +165,8 @@ class CodegenTest {
                     jmp [l15,USE]
                   }
                   block l17 [l15] {
-                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%2r12,DEF], [%4r13,DEF], [%6r14,DEF], [%8r15,DEF], [%10rbx,DEF], [%12rsp,DEF], [%14rbp,DEF]
                     mov [%17any,USE], [%48rax,DEF]
+                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%2r12,DEF], [%4r13,DEF], [%6r14,DEF], [%8r15,DEF], [%10rbx,DEF], [%12rsp,DEF], [%14rbp,DEF]
                   }
                 }
                 """;
@@ -292,8 +292,8 @@ class CodegenTest {
                     b [l15,USE]
                   }
                   block l17 [l15] {
-                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%17any,USE], [%19any,USE], [%21any,USE], [%23any,USE], [%25any,USE], [%2x19,DEF], [%4x20,DEF], [%6x21,DEF], [%8x22,DEF], [%10x23,DEF], [%12x24,DEF], [%14x25,DEF], [%16x26,DEF], [%18x27,DEF], [%20x28,DEF], [%22x29,DEF], [%24sp,DEF]
                     mov [%77x0,DEF], [%27any,USE]
+                    parmov [%3any,USE], [%5any,USE], [%7any,USE], [%9any,USE], [%11any,USE], [%13any,USE], [%15any,USE], [%17any,USE], [%19any,USE], [%21any,USE], [%23any,USE], [%25any,USE], [%2x19,DEF], [%4x20,DEF], [%6x21,DEF], [%8x22,DEF], [%10x23,DEF], [%12x24,DEF], [%14x25,DEF], [%16x26,DEF], [%18x27,DEF], [%20x28,DEF], [%22x29,DEF], [%24sp,DEF]
                   }
                 }
                 """;

--- a/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java
+++ b/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import java.util.BitSet;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,19 +21,25 @@ class MachineBasicBlockTest {
         MachineInstruction instruction1 = new MachineInstruction("hello", List.of());
         MachineInstruction instruction2 = new MachineInstruction("world", List.of());
         block.addBeforeTerminator(instruction1);
-        assertEquals(1, block.getTerminator());
+        assertNull(block.getTerminator());
         block.addBeforeTerminator(instruction2);
-        assertEquals(2, block.getTerminator());
-        assertEquals(List.of(instruction1, instruction2), block.getInstructions());
+        assertNull(block.getTerminator());
+        assertEquals(
+                List.of(instruction1, instruction2),
+                StreamSupport.stream(block.getInstructions().spliterator(), false).collect(Collectors.toList())
+        );
 
         MachineInstruction instruction3 = new MachineInstruction("foo", List.of());
         MachineInstruction instruction4 = new MachineInstruction("bar", List.of());
         MachineInstruction instruction5 = new MachineInstruction("bob", List.of());
-        block.getInstructions().add(instruction3);
-        block.getInstructions().add(instruction4);
+        block.getInstructions().addToEnd(instruction3);
+        block.getInstructions().addToEnd(instruction4);
         block.addBeforeTerminator(instruction5);
-        assertEquals(3, block.getTerminator());
-        assertEquals(List.of(instruction1, instruction2, instruction5, instruction3, instruction4), block.getInstructions());
+        assertEquals(instruction3, block.getTerminator());
+        assertEquals(
+                List.of(instruction1, instruction2, instruction5, instruction3, instruction4),
+                StreamSupport.stream(block.getInstructions().spliterator(), false).collect(Collectors.toList())
+        );
     }
 
     @Test
@@ -77,33 +85,33 @@ class MachineBasicBlockTest {
         MachineOperand r2 = fresh.get();
 
         // Add phi nodes to both successors:
-        successor1.getInstructions().add(new MachineInstruction("phi", List.of(
+        successor1.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(v0, MachineOperandKind.USE),
                 new MachineOperandPair(v1, MachineOperandKind.USE),
                 new MachineOperandPair(v2, MachineOperandKind.DEF)
         )));
-        successor1.getInstructions().add(new MachineInstruction("phi", List.of(
+        successor1.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(w0, MachineOperandKind.USE),
                 new MachineOperandPair(w1, MachineOperandKind.USE),
                 new MachineOperandPair(w2, MachineOperandKind.DEF)
         )));
-        successor1.getInstructions().add(new MachineInstruction("hello", List.of(
+        successor1.getInstructions().addToEnd(new MachineInstruction("hello", List.of(
                 new MachineOperandPair(v2, MachineOperandKind.USE),
                 new MachineOperandPair(w2, MachineOperandKind.USE),
                 new MachineOperandPair(r1, MachineOperandKind.DEF)
         )));
 
-        successor2.getInstructions().add(new MachineInstruction("phi", List.of(
+        successor2.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(x0, MachineOperandKind.USE),
                 new MachineOperandPair(x1, MachineOperandKind.USE),
                 new MachineOperandPair(x2, MachineOperandKind.DEF)
         )));
-        successor2.getInstructions().add(new MachineInstruction("phi", List.of(
+        successor2.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(y0, MachineOperandKind.USE),
                 new MachineOperandPair(y1, MachineOperandKind.USE),
                 new MachineOperandPair(y2, MachineOperandKind.DEF)
         )));
-        successor2.getInstructions().add(new MachineInstruction("hello", List.of(
+        successor2.getInstructions().addToEnd(new MachineInstruction("hello", List.of(
                 new MachineOperandPair(x2, MachineOperandKind.USE),
                 new MachineOperandPair(y2, MachineOperandKind.USE),
                 new MachineOperandPair(r2, MachineOperandKind.DEF)
@@ -131,17 +139,17 @@ class MachineBasicBlockTest {
         MachineOperand w2 = fresh.get();
 
         MachineOperand r = fresh.get();
-        block.getInstructions().add(new MachineInstruction("phi", List.of(
+        block.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(v0, MachineOperandKind.USE),
                 new MachineOperandPair(v1, MachineOperandKind.USE),
                 new MachineOperandPair(v2, MachineOperandKind.DEF)
         )));
-        block.getInstructions().add(new MachineInstruction("phi", List.of(
+        block.getInstructions().addToEnd(new MachineInstruction("phi", List.of(
                 new MachineOperandPair(w0, MachineOperandKind.USE),
                 new MachineOperandPair(w1, MachineOperandKind.USE),
                 new MachineOperandPair(w2, MachineOperandKind.DEF)
         )));
-        block.getInstructions().add(new MachineInstruction("hello", List.of(
+        block.getInstructions().addToEnd(new MachineInstruction("hello", List.of(
                 new MachineOperandPair(v2, MachineOperandKind.USE),
                 new MachineOperandPair(w2, MachineOperandKind.USE),
                 new MachineOperandPair(r, MachineOperandKind.DEF)

--- a/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java
+++ b/src/test/java/com/d_m/select/instr/MachineBasicBlockTest.java
@@ -24,10 +24,7 @@ class MachineBasicBlockTest {
         assertNull(block.getTerminator());
         block.addBeforeTerminator(instruction2);
         assertNull(block.getTerminator());
-        assertEquals(
-                List.of(instruction1, instruction2),
-                StreamSupport.stream(block.getInstructions().spliterator(), false).collect(Collectors.toList())
-        );
+        assertEquals(List.of(instruction1, instruction2), block.getInstructions().toList());
 
         MachineInstruction instruction3 = new MachineInstruction("foo", List.of());
         MachineInstruction instruction4 = new MachineInstruction("bar", List.of());
@@ -38,7 +35,7 @@ class MachineBasicBlockTest {
         assertEquals(instruction3, block.getTerminator());
         assertEquals(
                 List.of(instruction1, instruction2, instruction5, instruction3, instruction4),
-                StreamSupport.stream(block.getInstructions().spliterator(), false).collect(Collectors.toList())
+                block.getInstructions().toList()
         );
     }
 

--- a/src/test/java/com/d_m/ssa/BlockTest.java
+++ b/src/test/java/com/d_m/ssa/BlockTest.java
@@ -39,7 +39,7 @@ class BlockTest {
         ));
         instruction3.getSuccessors().add(new Block(function, List.of()));
         instruction3.getSuccessors().add(new Block(function, List.of()));
-        assertEquals(block.getInstructions().first, instruction1);
+        assertEquals(block.getInstructions().getFirst(), instruction1);
         assertEquals(block.getTerminator(), instruction3);
         assertEquals(2, block.getSuccessors().size());
         assertEquals(3, Iterables.size(block.getInstructions()));
@@ -54,12 +54,12 @@ class BlockTest {
         block.getInstructions().addToFront(instruction1);
         block.getInstructions().addBeforeLast(instruction2);
         assertEquals(2, Iterables.size(block.getInstructions()));
-        assertEquals(instruction2, block.getInstructions().first);
+        assertEquals(instruction2, block.getInstructions().getFirst());
         assertEquals(instruction1, block.getTerminator());
 
         block.getInstructions().addBeforeLast(instruction3);
         assertEquals(3, Iterables.size(block.getInstructions()));
-        assertEquals(instruction3, block.getInstructions().first.next);
+        assertEquals(instruction3, block.getInstructions().getFirst().getNext());
         assertEquals(instruction3, block.getTerminator().prev);
     }
 }

--- a/src/test/java/com/d_m/ssa/BlockTest.java
+++ b/src/test/java/com/d_m/ssa/BlockTest.java
@@ -44,22 +44,4 @@ class BlockTest {
         assertEquals(2, block.getSuccessors().size());
         assertEquals(3, Iterables.size(block.getInstructions()));
     }
-
-    @Test
-    void addInstructionBeforeTerminator() {
-        Block block = new Block(function, List.of());
-        block.getInstructions().addBeforeLast(instruction1);
-        assertEquals(0, Iterables.size(block.getInstructions()));
-
-        block.getInstructions().addToFront(instruction1);
-        block.getInstructions().addBeforeLast(instruction2);
-        assertEquals(2, Iterables.size(block.getInstructions()));
-        assertEquals(instruction2, block.getInstructions().getFirst());
-        assertEquals(instruction1, block.getTerminator());
-
-        block.getInstructions().addBeforeLast(instruction3);
-        assertEquals(3, Iterables.size(block.getInstructions()));
-        assertEquals(instruction3, block.getInstructions().getFirst().getNext());
-        assertEquals(instruction3, block.getTerminator().prev);
-    }
 }

--- a/src/test/java/com/d_m/ssa/ListWrapperTest.java
+++ b/src/test/java/com/d_m/ssa/ListWrapperTest.java
@@ -1,0 +1,166 @@
+package com.d_m.ssa;
+
+import com.d_m.ast.IntegerType;
+import com.d_m.code.Operator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ListWrapperTest {
+    @Test
+    void addToFront() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        Instruction inst1 = new Instruction("a", new IntegerType(), Operator.NOP);
+        Instruction inst2 = new Instruction("b", new IntegerType(), Operator.NOP);
+        instructions.addToFront(inst1);
+        assertEquals(instructions.getFirst(), inst1);
+        assertEquals(instructions.getLast(), inst1);
+        instructions.addToFront(inst2);
+        assertEquals(instructions.getFirst(), inst2);
+        assertEquals(instructions.getLast(), inst1);
+    }
+
+    @Test
+    void addAfter() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        Instruction inst1 = new Instruction("a", new IntegerType(), Operator.NOP);
+        Instruction inst2 = new Instruction("b", new IntegerType(), Operator.NOP);
+        Instruction inst3 = new Instruction("c", new IntegerType(), Operator.NOP);
+        instructions.addToEnd(inst1);
+        instructions.addAfter(inst1, inst2);
+        assertEquals(instructions.getLast(), inst2);
+        instructions.addAfter(inst1, inst3);
+        assertEquals(instructions.getFirst(), inst1);
+        assertEquals(instructions.getLast(), inst2);
+        assertEquals(instructions.toList(), List.of(inst1, inst3, inst2));
+    }
+
+    @Test
+    void addBefore() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        Instruction inst1 = new Instruction("a", new IntegerType(), Operator.NOP);
+        Instruction inst2 = new Instruction("b", new IntegerType(), Operator.NOP);
+        Instruction inst3 = new Instruction("c", new IntegerType(), Operator.NOP);
+        instructions.addToEnd(inst1);
+        instructions.addBefore(inst1, inst2);
+        assertEquals(instructions.getFirst(), inst2);
+        instructions.addBefore(inst1, inst3);
+        assertEquals(instructions.getFirst(), inst2);
+        assertEquals(instructions.getLast(), inst1);
+        assertEquals(instructions.toList(), List.of(inst2, inst3, inst1));
+    }
+
+    @Test
+    void addToEnd() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        Instruction inst1 = new Instruction("a", new IntegerType(), Operator.NOP);
+        Instruction inst2 = new Instruction("b", new IntegerType(), Operator.NOP);
+        instructions.addToEnd(inst1);
+        assertEquals(instructions.getFirst(), inst1);
+        assertEquals(instructions.getLast(), inst1);
+        instructions.addToEnd(inst2);
+        assertEquals(instructions.getFirst(), inst1);
+        assertEquals(instructions.getLast(), inst2);
+    }
+
+    @Test
+    void appendEmpty() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        ListWrapper<Instruction> emptyInstructions = new ListWrapper<>();
+        List<Instruction> expected = List.of(
+                new Instruction("a", new IntegerType(), Operator.NOP),
+                new Instruction("b", new IntegerType(), Operator.NOP),
+                new Instruction("c", new IntegerType(), Operator.NOP)
+        );
+        for (Instruction inst : expected) {
+            instructions.addToEnd(inst);
+        }
+        assertEquals(instructions.getFirst(), expected.getFirst());
+        assertEquals(instructions.getLast(), expected.getLast());
+        instructions.append(emptyInstructions);
+        assertEquals(instructions.getFirst(), expected.getFirst());
+        assertEquals(instructions.getLast(), expected.getLast());
+        emptyInstructions.append(instructions);
+        assertEquals(emptyInstructions.getFirst(), expected.getFirst());
+        assertEquals(emptyInstructions.getLast(), expected.getLast());
+    }
+
+    @Test
+    void append() {
+        ListWrapper<Instruction> firstInstructions = new ListWrapper<>();
+        ListWrapper<Instruction> secondInstructions = new ListWrapper<>();
+        List<Instruction> firstSet = List.of(
+                new Instruction("a", new IntegerType(), Operator.NOP),
+                new Instruction("b", new IntegerType(), Operator.NOP),
+                new Instruction("c", new IntegerType(), Operator.NOP)
+        );
+        List<Instruction> secondSet = List.of(
+                new Instruction("d", new IntegerType(), Operator.NOP),
+                new Instruction("e", new IntegerType(), Operator.NOP),
+                new Instruction("f", new IntegerType(), Operator.NOP)
+        );
+        for (Instruction inst : firstSet) {
+            firstInstructions.addToEnd(inst);
+        }
+        for (Instruction inst : secondSet) {
+            secondInstructions.addToEnd(inst);
+        }
+        firstInstructions.append(secondInstructions);
+        assertEquals(firstInstructions.toList(), Stream.concat(firstSet.stream(), secondSet.stream()).toList());
+    }
+
+    @Test
+    void iterator() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        List<Instruction> firstSet = List.of(
+                new Instruction("a", new IntegerType(), Operator.NOP),
+                new Instruction("b", new IntegerType(), Operator.NOP),
+                new Instruction("c", new IntegerType(), Operator.NOP),
+                new Instruction("d", new IntegerType(), Operator.NOP)
+        );
+        for (Instruction inst : firstSet) {
+            instructions.addToEnd(inst);
+        }
+        var it = instructions.iterator();
+        assertEquals(it.next(), firstSet.getFirst());
+        it.remove();
+        assertEquals(it.next(), firstSet.get(1));
+        assertEquals(it.next(), firstSet.get(2));
+        it.remove();
+        assertEquals(it.next(), firstSet.getLast());
+        it.remove();
+        assertFalse(it.hasNext());
+        assertEquals(instructions.toList(), List.of(firstSet.get(1)));
+        assertEquals(instructions.getFirst(), firstSet.get(1));
+        assertEquals(instructions.getLast(), firstSet.get(1));
+    }
+
+    @Test
+    void reversed() {
+        ListWrapper<Instruction> instructions = new ListWrapper<>();
+        assertFalse(instructions.reversed().hasNext());
+        List<Instruction> firstSet = List.of(
+                new Instruction("a", new IntegerType(), Operator.NOP),
+                new Instruction("b", new IntegerType(), Operator.NOP),
+                new Instruction("c", new IntegerType(), Operator.NOP),
+                new Instruction("d", new IntegerType(), Operator.NOP)
+        );
+        for (Instruction inst : firstSet) {
+            instructions.addToEnd(inst);
+        }
+        var it = instructions.reversed();
+        assertEquals(it.next(), firstSet.getLast());
+        it.remove();
+        assertEquals(it.next(), firstSet.get(2));
+        assertEquals(it.next(), firstSet.get(1));
+        it.remove();
+        assertEquals(it.next(), firstSet.getFirst());
+        it.remove();
+        assertEquals(instructions.toList(), List.of(firstSet.get(2)));
+        assertEquals(instructions.getFirst(), firstSet.get(2));
+        assertEquals(instructions.getLast(), firstSet.get(2));
+    }
+}


### PR DESCRIPTION
Currently machine blocks contain an ArrayList of machine instructions. This was done for convenience, but causes problems when trying to insert instructions in the middle of a block. This PR moves machine instructions to use the same wrapped linked list type as the SSA instructions before instruction selection. It also fixes some bugs with the linked list functions and adds unit tests.